### PR TITLE
Remove fontspark.app from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@
 
 - [Google Fonts](https://fonts.google.com)
 - [Font Flipper](https://fontflipper.com/)
-- [FontSpark](https://fontspark.app/)
 - [ColorAndFonts](https://www.colorsandfonts.com/)
 - [FontPair](https://fontpair.co/)
 


### PR DESCRIPTION
Fontspark.app is no longer available as a service.